### PR TITLE
Updated clang format to not reflow comments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,7 +87,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
-ReflowComments:  true
+ReflowComments:  false
 SortIncludes:    true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false


### PR DESCRIPTION
Updated clang format to NOT reflow comment blocks.  This preserves original developer formating
